### PR TITLE
fix: remove postinstall script due to npm error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,13 @@
 
 ## Development Workflow
 
-1. Create a feature branch from `main`
-2. Make your changes with conventional commits
-3. Push and create a Pull Request
-4. CI runs tests, linting, and type checking
-5. After approval, rebase and merge to `main`
-6. Semantic Release automatically creates a new version
+1. Run `pnpm install` to install dependencies and set up Git hooks via Husky
+2. Create a feature branch from `main`
+3. Make your changes with conventional commits
+4. Push and create a Pull Request
+5. CI runs tests, linting, and type checking
+6. After approval, rebase and merge to `main`
+7. Semantic Release automatically creates and publishes a new version
 
 ## Commit Convention
 
@@ -17,6 +18,20 @@ Use conventional commits for automatic versioning:
 - `fix:` - Bug fix (patch version)
 - `feat!:` or `BREAKING CHANGE:` - Breaking change (major version)
 - `docs:`, `chore:`, `test:` - No version bump
+
+## Husky setup
+
+This project relies on Husky for Git hooks. Husky is installed as a dev dependency, so
+the hooks have to be configured locally:
+
+- `pnpm install` (or `npm install`) runs the `prepare` lifecycle script, which invokes
+  Husky and writes the hooks into `.git/hooks`.
+- The `prepare` script also runs automatically before `pnpm publish`, `pnpm pack`, and
+  when installing the project from a Git URL. This ensures the hooks are present for
+  contributors and before release builds are created.
+- Unlike `postinstall`, `prepare` is skipped for consumers installing the published
+  package from the npm registry. That keeps end users from needing Husky (or other dev
+  tooling) in their production environments **across all package managers**.
 
 ## Code Quality
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "prepare": "husky",
-    "postinstall": "husky",
     "prepublishOnly": "pnpm build",
     "release": "semantic-release"
   },


### PR DESCRIPTION
The postinstall scrtip executing `husky` was causing the errors regarding npm consumer installation. Modern package managers such as pnpm ignore these scripts by default for security concerns so the installation was successful there. The new approach includes relying solely on the `prepare` script that is not being executed each consumer install and especially is not being executed in npm package manager installs.
